### PR TITLE
Reader/writer for deleting URIs

### DIFF
--- a/src/main/java/com/marklogic/client/spring/DatabaseConfig.java
+++ b/src/main/java/com/marklogic/client/spring/DatabaseConfig.java
@@ -9,36 +9,31 @@ import org.springframework.core.env.Environment;
 
 import com.marklogic.client.helper.DatabaseClientConfig;
 import com.marklogic.client.helper.DatabaseClientProvider;
-import com.marklogic.xcc.template.XccTemplate;
 
 @Configuration
 @PropertySource("config/application.properties")
 public class DatabaseConfig {
-	
-	@Autowired
-	private Environment env;
 
-	protected String getHost() {
-		return env.getProperty("marklogic.host", "localhost");
-	}
-	
-	protected int getPort() {
-		return Integer.parseInt(env.getProperty("marklogic.port", "8000"));
-	}
-	
-	protected String getUser() {
-		return env.getProperty("marklogic.user", "admin");
-	}
-	
-	protected String getPassword() {
-		return env.getProperty("marklogic.password", "admin");
-	}
-	
-	protected String getDatabaseName() {
-		return env.getProperty("marklogic.database", "Documents");
-	}
-	
-	@Bean
+    @Autowired
+    private Environment env;
+
+    protected String getHost() {
+        return env.getProperty("marklogic.host", "localhost");
+    }
+
+    protected int getPort() {
+        return Integer.parseInt(env.getProperty("marklogic.port", "8000"));
+    }
+
+    protected String getUser() {
+        return env.getProperty("marklogic.user", "admin");
+    }
+
+    protected String getPassword() {
+        return env.getProperty("marklogic.password", "admin");
+    }
+
+    @Bean
     public static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
         PropertySourcesPlaceholderConfigurer c = new PropertySourcesPlaceholderConfigurer();
         c.setIgnoreResourceNotFound(true);
@@ -48,11 +43,6 @@ public class DatabaseConfig {
     @Bean
     public DatabaseClientConfig databaseClientConfig() {
         return new DatabaseClientConfig(getHost(), getPort(), getUser(), getPassword());
-    }
-
-    @Bean
-    public XccTemplate xccTemplate() {
-        return new XccTemplate(String.format("xcc://%s:%s@%s:8000/%s", getUser(), getPassword(), getHost(), getDatabaseName()));
     }
 
     @Bean

--- a/src/main/java/com/marklogic/client/spring/batch/reader/CollectionUrisReader.java
+++ b/src/main/java/com/marklogic/client/spring/batch/reader/CollectionUrisReader.java
@@ -1,0 +1,59 @@
+package com.marklogic.client.spring.batch.reader;
+
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemStream;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.eval.EvalResultIterator;
+import com.marklogic.client.helper.LoggingObject;
+
+/**
+ * A reader for returning all the URIs in a collection.
+ */
+public class CollectionUrisReader extends LoggingObject implements ItemReader<String>, ItemStream {
+
+    private DatabaseClient client;
+    private EvalResultIterator resultIterator;
+    private String[] collections;
+
+    public CollectionUrisReader(DatabaseClient client, String... collections) {
+        this.client = client;
+        this.collections = collections;
+    }
+
+    @Override
+    public String read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        return resultIterator.hasNext() ? resultIterator.next().getAs(String.class) : null;
+    }
+
+    @Override
+    public void open(ExecutionContext executionContext) {
+        String xquery = buildUrisQuery();
+        logger.info("Reading URIs via query: " + xquery);
+        resultIterator = client.newServerEval().xquery(xquery).eval();
+    }
+
+    protected String buildUrisQuery() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < collections.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(format("'%s'", collections[i]));
+        }
+        return format("cts:uris((), (), cts:collection-query((%s)))", sb);
+    }
+
+    @Override
+    public void update(ExecutionContext executionContext) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/marklogic/client/spring/batch/writer/DeleteUriWriter.java
+++ b/src/main/java/com/marklogic/client/spring/batch/writer/DeleteUriWriter.java
@@ -1,0 +1,29 @@
+package com.marklogic.client.spring.batch.writer;
+
+import java.util.List;
+
+import org.springframework.batch.item.ItemWriter;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.helper.LoggingObject;
+
+/**
+ * Simple writer that expects a list of URIs, and then uses the Client API to delete those URIs.
+ */
+public class DeleteUriWriter extends LoggingObject implements ItemWriter<String> {
+
+    private DatabaseClient client;
+
+    public DeleteUriWriter(DatabaseClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void write(List<? extends String> items) throws Exception {
+        if (logger.isInfoEnabled()) {
+            logger.info("Deleting URIs: " + items);
+        }
+        client.newDocumentManager().delete(items.toArray(new String[] {}));
+    }
+
+}

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -1,5 +1,5 @@
-marklogic.host=faa
-marklogic.port=8100
+marklogic.host=localhost
+marklogic.port=8000
 marklogic.user=admin
 marklogic.password=admin
 

--- a/src/test/java/com/marklogic/client/spring/batch/AbstractBatchTest.java
+++ b/src/test/java/com/marklogic/client/spring/batch/AbstractBatchTest.java
@@ -1,0 +1,50 @@
+package com.marklogic.client.spring.batch;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.marklogic.junit.spring.AbstractSpringTest;
+
+@ContextConfiguration(classes = { TestConfig.class })
+public class AbstractBatchTest extends AbstractSpringTest {
+
+    @Autowired
+    protected JobLauncher jobLauncher;
+
+    @Autowired
+    protected StepBuilderFactory stepBuilderFactory;
+
+    @Autowired
+    protected JobBuilderFactory jobBuilderFactory;
+
+    /**
+     * Convenience method for testing a single step; the subclass doesn't have to bother with creating a job.
+     * 
+     * @param step
+     * @return
+     */
+    protected void launchJobWithStep(Step step) {
+        Job job = jobBuilderFactory.get("testJob").start(step).build();
+        JobLauncherTestUtils utils = new JobLauncherTestUtils();
+        utils.setJobLauncher(jobLauncher);
+        utils.setJob(job);
+
+        JobExecution jobExecution = null;
+        try {
+            jobExecution = utils.launchJob();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        logger.info(
+                "Job execution time: " + (jobExecution.getEndTime().getTime() - jobExecution.getStartTime().getTime()));
+    }
+}

--- a/src/test/java/com/marklogic/client/spring/batch/DeleteUrisTest.java
+++ b/src/test/java/com/marklogic/client/spring/batch/DeleteUrisTest.java
@@ -1,0 +1,70 @@
+package com.marklogic.client.spring.batch;
+
+import org.junit.Test;
+
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.spring.batch.reader.CollectionUrisReader;
+import com.marklogic.client.spring.batch.writer.DeleteUriWriter;
+
+public class DeleteUrisTest extends AbstractBatchTest {
+
+    private final static int NUMBER_OF_DOCUMENTS_TO_CREATE = 2500;
+    private final static int NUMBER_OF_DOCUMENTS_TO_DELETE_AT_ONE_TIME = 100;
+
+    @Test
+    public void test() {
+        givenSomeDocumentsInTheTestCollection();
+        whenAJobIsRunToDeleteAllTheUrisInTheTestCollection();
+        thenTheTestCollectionIsNowEmpty();
+    }
+
+    /**
+     * Use the Client API to load a bunch of documents. This has no dependency on Spring Batch, we're just loading some
+     * documents that we'll then delete using Spring Batch.
+     */
+    private void givenSomeDocumentsInTheTestCollection() {
+        XMLDocumentManager mgr = getClient().newXMLDocumentManager();
+        DocumentWriteSet set = mgr.newWriteSet();
+        int count = 0;
+        // Write the documents in batches of 100
+        logger.info("Loading " + NUMBER_OF_DOCUMENTS_TO_CREATE + " documents");
+        long start = System.currentTimeMillis();
+        for (int i = 1; i <= NUMBER_OF_DOCUMENTS_TO_CREATE; i++) {
+            set.add("/doc/" + i + ".xml", new DocumentMetadataHandle().withCollections("test"),
+                    new StringHandle("<test>" + i + "</test>"));
+            count++;
+            if (count == 100) {
+                mgr.write(set);
+                set = mgr.newWriteSet();
+                count = 0;
+            }
+        }
+        logger.info("Loaded documents in " + (System.currentTimeMillis() - start) + "ms");
+    }
+
+    /**
+     * Launch a job with a step that uses CollectionUrisReader to read all the URIs from the "test" collection, and then
+     * uses DeleteUriWriter to delete every URI that is read. The URIs are chunked together to avoid making a delete
+     * call per URI.
+     */
+    private void whenAJobIsRunToDeleteAllTheUrisInTheTestCollection() {
+        launchJobWithStep(
+                stepBuilderFactory.get("testStep").<String, String> chunk(NUMBER_OF_DOCUMENTS_TO_DELETE_AT_ONE_TIME)
+                        .reader(new CollectionUrisReader(getClient(), "test")).writer(new DeleteUriWriter(getClient()))
+                        .build());
+
+    }
+
+    /**
+     * Use the Client API to verify that the test collection is now empty.
+     */
+    private void thenTheTestCollectionIsNowEmpty() {
+        String result = getClient().newServerEval().xquery("collection('test')").evalAs(String.class);
+        assertNull(
+                "The test collection should be empty because the job deleted all the documents we inserted into the collection",
+                result);
+    }
+}

--- a/src/test/java/com/marklogic/client/spring/batch/TestConfig.java
+++ b/src/test/java/com/marklogic/client/spring/batch/TestConfig.java
@@ -1,0 +1,14 @@
+package com.marklogic.client.spring.batch;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+
+import com.marklogic.client.spring.DatabaseConfig;
+
+/**
+ * Uses EnableBatchProcessing, which defaults to using ResourcelessTransactionManager if a DataSource cannot be found,
+ * which is what we want for MarkLogic tests.
+ */
+@EnableBatchProcessing
+public class TestConfig extends DatabaseConfig {
+
+}


### PR DESCRIPTION
This uses CollectionUrisReader and DeleteUriWriter to delete all the URIs in a collection. I modified application.properties to default to localhost:8000 instead of faa:8100. 

Working on this led me to the following thoughts:

1. I think src/main/java should primarily contain Reader/Processor/Writer implementations specific to MarkLogic.
1. src/test/java should then contain all the Config classes that are specific to certain kinds of tests. 
1. I think "client" can be removed from the package - "com.marklogic.spring.batch" seems right, with "reader", "writer", and "processor" subpackages. 
