### PR TITLE
#101 Reworked AbstractJobTest to not depend on a Spring configuration…

### DIFF
--- a/jobs/src/test/java/com/marklogic/spring/batch/config/AbstractJobsJobTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/config/AbstractJobsJobTest.java
@@ -1,0 +1,12 @@
+package com.marklogic.spring.batch.config;
+
+import com.marklogic.spring.batch.test.AbstractJobTest;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Reuses the test project's AbstractJobTest class and defines a Spring configuration for
+ * loading properties.
+ */
+@ContextConfiguration(classes = {JobTestConfig.class})
+public abstract class AbstractJobsJobTest extends AbstractJobTest {
+}

--- a/jobs/src/test/java/com/marklogic/spring/batch/config/ImportRdfFromFileTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/config/ImportRdfFromFileTest.java
@@ -6,7 +6,7 @@ import com.marklogic.spring.batch.config.sql.ReadAndWriteColumnMapsTest;
 import com.marklogic.spring.batch.test.AbstractJobTest;
 import org.junit.Test;
 
-public class ImportRdfFromFileTest extends AbstractJobTest {
+public class ImportRdfFromFileTest extends AbstractJobsJobTest {
 
     @Test
     public void test() {

--- a/jobs/src/test/java/com/marklogic/spring/batch/config/JobTestConfig.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/config/JobTestConfig.java
@@ -1,4 +1,4 @@
-package com.marklogic.spring.batch.test;
+package com.marklogic.spring.batch.config;
 
 import com.marklogic.client.spring.BasicConfig;
 import org.springframework.context.annotation.Configuration;

--- a/jobs/src/test/java/com/marklogic/spring/batch/config/sql/AbstractHsqlTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/config/sql/AbstractHsqlTest.java
@@ -1,5 +1,6 @@
 package com.marklogic.spring.batch.config.sql;
 
+import com.marklogic.spring.batch.config.AbstractJobsJobTest;
 import com.marklogic.spring.batch.test.AbstractJobTest;
 import org.junit.After;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
@@ -9,7 +10,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 /**
  * Provides some support for tests that need to stand up an embedded HSQL database.
  */
-public abstract class AbstractHsqlTest extends AbstractJobTest {
+public abstract class AbstractHsqlTest extends AbstractJobsJobTest {
 
     protected static EmbeddedDatabase embeddedDatabase;
 

--- a/jobs/src/test/java/com/marklogic/spring/batch/job/CorbJobTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/job/CorbJobTest.java
@@ -5,10 +5,10 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.junit.Fragment;
-import com.marklogic.spring.batch.test.AbstractJobTest;
+import com.marklogic.spring.batch.config.AbstractJobsJobTest;
 import org.junit.Test;
 
-public class CorbJobTest extends AbstractJobTest {
+public class CorbJobTest extends AbstractJobsJobTest {
 
     @Test
     public void runCorbJobTest() {

--- a/jobs/src/test/java/com/marklogic/spring/batch/job/DeleteDocumentsTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/job/DeleteDocumentsTest.java
@@ -5,10 +5,10 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.junit.Fragment;
-import com.marklogic.spring.batch.test.AbstractJobTest;
+import com.marklogic.spring.batch.config.AbstractJobsJobTest;
 import org.junit.Test;
 
-public class DeleteDocumentsTest extends AbstractJobTest {
+public class DeleteDocumentsTest extends AbstractJobsJobTest {
 
     private final static int NUMBER_OF_DOCUMENTS_TO_CREATE = 200;
 

--- a/jobs/src/test/java/com/marklogic/spring/batch/job/LoadDocumentsFromDirectoryJobTest.java
+++ b/jobs/src/test/java/com/marklogic/spring/batch/job/LoadDocumentsFromDirectoryJobTest.java
@@ -6,10 +6,10 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.junit.ClientTestHelper;
 import com.marklogic.junit.Fragment;
-import com.marklogic.spring.batch.test.AbstractJobTest;
+import com.marklogic.spring.batch.config.AbstractJobsJobTest;
 import org.junit.Test;
 
-public class LoadDocumentsFromDirectoryJobTest extends AbstractJobTest {
+public class LoadDocumentsFromDirectoryJobTest extends AbstractJobsJobTest {
 
     @Test
     public void loadXmlDocumentsTest() {

--- a/test/src/main/java/com/marklogic/spring/batch/test/AbstractJobTest.java
+++ b/test/src/main/java/com/marklogic/spring/batch/test/AbstractJobTest.java
@@ -3,12 +3,13 @@ package com.marklogic.spring.batch.test;
 import com.marklogic.client.spring.BasicConfig;
 import com.marklogic.junit.NamespaceProvider;
 import com.marklogic.junit.spring.AbstractSpringTest;
+import com.marklogic.junit.spring.BasicTestConfig;
 import com.marklogic.spring.batch.Main;
 import com.marklogic.spring.batch.Options;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,28 +17,52 @@ import java.util.List;
 /**
  * Base class for any marklogic-spring-batch test that needs to run a job. Uses the Main program
  * to collect command line arguments and run a job.
+ * <p>
+ * Key note - this does not specify a particular Spring configuration class - you are free to use
+ * any Spring class that you want. But the buildArgsForConfig method assumes that it can find either
+ * an instance of com.marklogic.client.spring.BasicConfig or com.marklogic.junit.spring.BasicTestConfig
+ * so that it knows what ML connection arguments to construct. If you don't use either of those,
+ * you'll need to override the getMlConnectionArgs method.
  */
-@ContextConfiguration(classes = {JobTestConfig.class})
 public abstract class AbstractJobTest extends AbstractSpringTest {
-
-    @Autowired
-    private BasicConfig testConfig;
 
     @Override
     protected NamespaceProvider getNamespaceProvider() {
         return new SpringBatchNamespaceProvider();
     }
 
+    /**
+     * Assumes that the given config class defines a single Job bean, and runs it.
+     *
+     * @param clazz
+     * @param otherArgs arguments to be passed in, in addition to the ML connection arguments
+     * @return
+     */
     protected JobExecution runJob(Class<?> clazz, Object... otherArgs) {
         String[] args = buildArgsForConfig(clazz, false, otherArgs);
         return runJob(args);
     }
 
+    /**
+     * Assumes that the given config class defines a single Job bean, and runs it. Passes in the
+     * ML connection arguments for the job repository connection parameters, thus enabling the MarkLogic
+     * JobRepository implementation.
+     *
+     * @param clazz
+     * @param otherArgs
+     * @return
+     */
     protected JobExecution runJobWithMarkLogicJobRepository(Class<?> clazz, Object... otherArgs) {
         String[] args = buildArgsForConfig(clazz, true, otherArgs);
         return runJob(args);
     }
 
+    /**
+     * Run a job with the given arguments.
+     *
+     * @param args
+     * @return
+     */
     protected JobExecution runJob(String[] args) {
         JobExecution exec = null;
         try {
@@ -49,29 +74,39 @@ public abstract class AbstractJobTest extends AbstractSpringTest {
         return exec;
     }
 
-    protected String arg(String name) {
-        return "--" + name;
-    }
-
+    /**
+     * @param configClass
+     * @param enableMarkLogicJobRepository
+     * @param otherArgs
+     * @return an array of args that can be passed into the marklogic-spring-batch Main program. Assumes
+     * that only host, port, username, and password are needed. If that's not the case, you can always pass
+     * in additional arguments via the "otherArgs" parameter.
+     */
     protected String[] buildArgsForConfig(Class<?> configClass, boolean enableMarkLogicJobRepository, Object... otherArgs) {
+        String[] connectionArgs = getMlConnectionArgs();
+        String host = connectionArgs[0];
+        String port = connectionArgs[1];
+        String username = connectionArgs[2];
+        String password = connectionArgs[3];
+
         List<String> args = new ArrayList<>();
         args.add(arg(Options.HOST));
-        args.add(testConfig.getMlHost());
+        args.add(host);
         args.add(arg(Options.PORT));
-        args.add(testConfig.getMlRestPort().toString());
+        args.add(port);
         args.add(arg(Options.USERNAME));
-        args.add(testConfig.getMlUsername());
+        args.add(username);
         args.add(arg(Options.PASSWORD));
-        args.add(testConfig.getMlPassword());
+        args.add(password);
         if (enableMarkLogicJobRepository) {
             args.add(arg(Options.JOB_REPOSITORY_HOST));
-            args.add(testConfig.getMlHost());
+            args.add(host);
             args.add(arg(Options.JOB_REPOSITORY_PORT));
-            args.add(testConfig.getMlRestPort().toString());
+            args.add(port);
             args.add(arg(Options.JOB_REPOSITORY_USERNAME));
-            args.add(testConfig.getMlUsername());
+            args.add(username);
             args.add(arg(Options.JOB_REPOSITORY_PASSWORD));
-            args.add(testConfig.getMlPassword());
+            args.add(password);
         }
         args.add(arg(Options.CONFIG));
         args.add(configClass.getName());
@@ -79,5 +114,34 @@ public abstract class AbstractJobTest extends AbstractSpringTest {
             args.add(arg.toString());
         }
         return args.toArray(new String[]{});
+    }
+
+    /**
+     * @param name
+     * @return assumes that the argument should use the "long" form supported by joptsimple
+     */
+    protected String arg(String name) {
+        return "--" + name;
+    }
+
+    /**
+     * @return an array of 4 arguments - host, port, username, and password. These are used
+     * by buildArgsForConfig. You can override this in case your class does not use BasicConfig or
+     * BasicTestConfig.
+     */
+    protected String[] getMlConnectionArgs() {
+        ApplicationContext ctx = getApplicationContext();
+        BasicConfig config = ctx.getBean(BasicConfig.class);
+        String mlHost = config.getMlHost();
+        String mlUsername = config.getMlUsername();
+        String mlPassword = config.getMlPassword();
+        Integer port = config.getMlRestPort();
+        try {
+            BasicTestConfig testConfig = ctx.getBean(BasicTestConfig.class);
+            port = testConfig.getMlTestRestPort();
+        } catch (NoSuchBeanDefinitionException ex) {
+            // ignore
+        }
+        return new String[]{mlHost, port.toString(), mlUsername, mlPassword};
     }
 }

--- a/test/src/main/java/com/marklogic/spring/batch/test/SpringBatchNamespaceProvider.java
+++ b/test/src/main/java/com/marklogic/spring/batch/test/SpringBatchNamespaceProvider.java
@@ -7,14 +7,13 @@ import org.jdom2.Namespace;
 import java.util.List;
 
 /**
- * Had to duplicate this under jobs because it wasn't found under core.
+ * Registers commonly used namespaces for marklogic-spring-batch tests.
  */
 public class SpringBatchNamespaceProvider extends MarkLogicNamespaceProvider {
 	
 	@Override
     protected List<Namespace> buildListOfNamespaces() {
         List<Namespace> list = super.buildListOfNamespaces();
-        list.add(Namespace.getNamespace("geo", "http://geonames.org"));
         list.add(Namespace.getNamespace(MarkLogicSpringBatch.JOB_NAMESPACE_PREFIX, MarkLogicSpringBatch.JOB_NAMESPACE));
         list.add(Namespace.getNamespace("xs", "http://www.w3.org/2001/XMLSchema"));  
         list.add(Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance"));  


### PR DESCRIPTION
… class

This does mean that any application that extends AbstractJobTest needs to define their own Spring configuration class that can load up properties. But I think that's reasonable. A project should almost always make their own "Abstract(ProjectName)Test" class that extends AbstractJobTest, and the project should define the Spring configuration class they want to use. 