### PR TITLE
Porting BatchItemWriter over from ml-migration-starter. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ subprojects {
         compile 'org.slf4j:slf4j-api:1.7.21'
         compile "org.springframework.batch:spring-batch-core:$springVersion"
         compile "com.marklogic:java-client-api:4.0.0-EA4"
-        compile "com.marklogic:ml-javaclient-util:2.11.0"
+        compile "com.marklogic:ml-javaclient-util:2.12.0"
 
         testCompile "org.springframework.batch:spring-batch-test:$springVersion"
         testCompile "com.marklogic:ml-junit:2.6.0"
@@ -130,7 +130,7 @@ project(':core') {
         runtime "org.springframework.batch:spring-batch-core:$springVersion"
 
         //com.marklogic.spring.batch.Main extends com.marklogic.client.helper.LoggingObject
-        runtime "com.marklogic:ml-javaclient-util:2.11.0"
+        runtime "com.marklogic:ml-javaclient-util:2.12.0"
 
         runtime "org.springframework:spring-jdbc:4.2.6.RELEASE"
 

--- a/examples/rdbms_2/build.gradle
+++ b/examples/rdbms_2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "com.marklogic:ml-javaclient-util:2.9.1"
+    compile "com.marklogic:ml-javaclient-util:2.12.0"
 
     // https://mvnrepository.com/artifact/org.springframework/spring-jdbc
     compile "org.springframework:spring-jdbc:4.3.1.RELEASE"

--- a/infrastructure/src/main/java/com/marklogic/client/io/MarkLogicWriteHandle.java
+++ b/infrastructure/src/main/java/com/marklogic/client/io/MarkLogicWriteHandle.java
@@ -6,6 +6,12 @@ import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Use the Java Client DocumentWriteOperationImpl class instead.
+ *
+ * TODO Remove this before 1.0.0?
+ */
+@Deprecated
 public class MarkLogicWriteHandle implements DocumentWriteOperation {
     
     protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/infrastructure/src/main/java/com/marklogic/spring/batch/columnmap/ColumnMapSerializer.java
+++ b/infrastructure/src/main/java/com/marklogic/spring/batch/columnmap/ColumnMapSerializer.java
@@ -3,7 +3,8 @@ package com.marklogic.spring.batch.columnmap;
 import java.util.Map;
 
 /**
- * COPY/PASTED from rowToDoc. Should probably live in marklogic-spring-batch.
+ * Strategy interface for how a Spring "column map" can be written to a String of JSON or XML or, really, whatever you
+ * want.
  */
 public interface ColumnMapSerializer {
 

--- a/infrastructure/src/main/java/com/marklogic/spring/batch/columnmap/DefaultStaxColumnMapSerializer.java
+++ b/infrastructure/src/main/java/com/marklogic/spring/batch/columnmap/DefaultStaxColumnMapSerializer.java
@@ -10,7 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * COPY/PASTED from rowToDoc. Should probably live in marklogic-spring-batch.
+ * Simple implementation that uses StAX - https://docs.oracle.com/javase/tutorial/jaxp/stax/index.html - for generating
+ * an XML document from a Spring column map.
  */
 public class DefaultStaxColumnMapSerializer extends LoggingObject implements ColumnMapSerializer {
 

--- a/infrastructure/src/main/java/com/marklogic/spring/batch/item/writer/BatchItemWriter.java
+++ b/infrastructure/src/main/java/com/marklogic/spring/batch/item/writer/BatchItemWriter.java
@@ -1,0 +1,55 @@
+package com.marklogic.spring.batch.item.writer;
+
+import com.marklogic.client.batch.*;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.helper.LoggingObject;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStream;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemWriter;
+
+import java.util.List;
+
+/**
+ * ItemWriter that depends on an instance of BatchWriter from ml-javaclient-util. That interface abstracts away whether
+ * REST or XCC (and in the future, DMSDK) is being used.
+ */
+public class BatchItemWriter extends LoggingObject implements ItemWriter<DocumentWriteOperation>, ItemStream {
+
+	private com.marklogic.client.batch.BatchWriter batchWriter;
+
+	public BatchItemWriter(com.marklogic.client.batch.BatchWriter batchWriter) {
+		this.batchWriter = batchWriter;
+	}
+
+	@Override
+	public void write(List<? extends DocumentWriteOperation> items) throws Exception {
+		batchWriter.write(items);
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		if (logger.isInfoEnabled()) {
+			logger.info("On stream open, initializing BatchWriter");
+		}
+		batchWriter.initialize();
+		if (logger.isInfoEnabled()) {
+			logger.info("On stream open, finished initializing BatchWriter");
+		}
+	}
+
+	@Override
+	public void close() throws ItemStreamException {
+		if (logger.isInfoEnabled()) {
+			logger.info("On stream close, waiting for BatchWriter to complete");
+		}
+		batchWriter.waitForCompletion();
+		if (logger.isInfoEnabled()) {
+			logger.info("On stream close, finished waiting for BatchWriter to complete");
+		}
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext) throws ItemStreamException {
+	}
+}


### PR DESCRIPTION
Also - Upgraded ml-javaclient-util to 2.12.0. Also marked MarkLogicWriteHandle as deprecated.

Note that ml-javaclient-util 2.12.0 has the "BatchWriter" interface in it. That creates some confusion with the "BatchWriter" item writer in this project. 

I think "BatchWriter" in this project should be moved elsewhere, as it's not a Writer, it's a Runnable. I'm also thinking that the UriTransformer should live elsewhere, like in a Processor or Writer - i.e. by the time BatchWriter gets the DocumentWriteOperation, the URI has already been set. 